### PR TITLE
Fix unsigned integer overflow and directly returning 502 when incoming requests exceed slots

### DIFF
--- a/src/balancer/http_route/receive_status_update.rs
+++ b/src/balancer/http_route/receive_status_update.rs
@@ -19,7 +19,7 @@ struct RemovePeerGuard<'a> {
     agent_id: String,
 }
 
-impl<'a> Drop for RemovePeerGuard<'a> {
+impl Drop for RemovePeerGuard<'_> {
     fn drop(&mut self) {
         info!("Removing agent: {}", self.agent_id);
 
@@ -60,6 +60,5 @@ async fn respond(
             }
         }
     }
-
     Ok(HttpResponse::Accepted().finish())
 }

--- a/src/balancer/proxy_service.rs
+++ b/src/balancer/proxy_service.rs
@@ -246,10 +246,15 @@ impl ProxyHttp for ProxyService {
                 Ok(peer) => peer,
                 Err(e) => {
                     // ideally unreachable
-                    error!("Can't get peer even under permits: {e}");
+                    error!("Failed to get peer even under permits: {e}");
                     return Err(Error::new(pingora::InternalError));
                 }
             };
+
+            if ctx.selected_peer.is_none() {
+                error!("Failed to get peer even under permits!");
+                return Err(Error::new(pingora::InternalError));
+            }
 
             let store_res = self
                 .upstream_peer_pool
@@ -259,13 +264,13 @@ impl ProxyHttp for ProxyService {
                 Ok(r) => {
                     if !r {
                         // ideally unreachable
-                        error!("Can't get peer even under permits!");
+                        error!("Failed to get peer even under permits!");
                         return Err(Error::new(pingora::InternalError));
                     }
                 }
                 Err(e) => {
                     // ideally unreachable
-                    error!("Can't get peer even under permits: {e}");
+                    error!("Failed to get peer even under permits: {e}");
                     return Err(Error::new(pingora::InternalError));
                 }
             }

--- a/src/cmd/dashboard/app.rs
+++ b/src/cmd/dashboard/app.rs
@@ -13,15 +13,14 @@ use ratatui::{
     },
     Frame,
 };
+use serde::Deserialize;
 use std::{
-    io,
-    time::{SystemTime, UNIX_EPOCH},
+    io, net::SocketAddr, time::{SystemTime, UNIX_EPOCH}
 };
 
 use super::ui::TableColors;
 
 use crate::{
-    balancer::{upstream_peer::UpstreamPeer, upstream_peer_pool::UpstreamPeerPool},
     errors::result::Result,
 };
 
@@ -238,8 +237,7 @@ impl App {
     pub fn set_registered_agents(&mut self, upstream_peer_pool: UpstreamPeerPool) -> Result<()> {
         let registered_agents = upstream_peer_pool
             .agents
-            .read()
-            .map(|agents_guard| agents_guard.clone())?;
+            .clone();
 
         self.items = Some(registered_agents);
         self.is_initial_load = false;
@@ -279,4 +277,19 @@ fn systemtime_strftime(dt: SystemTime) -> Result<String> {
     let formated_date = datetime.format("%Y/%m/%d, %H:%M:%S").to_string();
 
     Ok(formated_date)
+}
+
+#[derive(Deserialize, Clone)]
+pub struct UpstreamPeer {
+    pub agent_name: Option<String>,
+    pub error: Option<String>,
+    pub external_llamacpp_addr: SocketAddr,
+    pub last_update: SystemTime,
+    pub slots_idle: usize,
+    pub slots_processing: usize,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct UpstreamPeerPool {
+    pub agents: Vec<UpstreamPeer>
 }

--- a/src/cmd/dashboard/mod.rs
+++ b/src/cmd/dashboard/mod.rs
@@ -19,7 +19,7 @@ use tokio::{
 };
 
 use crate::{
-    balancer::upstream_peer_pool::UpstreamPeerPool, cmd::dashboard::app::App,
+     cmd::dashboard::app::UpstreamPeerPool, cmd::dashboard::app::App,
     errors::result::Result,
 };
 


### PR DESCRIPTION
It is pointed out in #46 that a 502 error would be returned directly when the number of requests exceeds the number of slots, and I discovered an unsigned integer overflow also happen in that case. I found that this was caused by improper synchronization. Therefore, I fixed this issue by using  semaphore.

However, now when the number of requests is high, there are occasional errors reported as "Error while proxying: Upstream ConnectionClosed." The system returns to normal after automatic retries, and this does not affect usage. I'm sorry that I have not been able to find a solution to this problem after serval attempts, further debug is needed to determine the issue.

Hope my contributions can be of some help.