### PR TITLE
fix: prevent race and underflow in slot counters

### DIFF
--- a/src/balancer/upstream_peer_pool.rs
+++ b/src/balancer/upstream_peer_pool.rs
@@ -14,6 +14,18 @@ pub struct UpstreamPeerPool {
     pub agents: RwLock<Vec<UpstreamPeer>>,
 }
 
+impl Clone for UpstreamPeerPool {
+    fn clone(&self) -> Self {
+        let agents = self.with_agents_read(|agents| {
+            Ok(agents.clone())
+        }).unwrap_or_default();
+        
+        UpstreamPeerPool {
+            agents: RwLock::new(agents),
+        }
+    }
+}
+
 impl UpstreamPeerPool {
     pub fn new() -> Self {
         UpstreamPeerPool {
@@ -54,21 +66,41 @@ impl UpstreamPeerPool {
         })
     }
 
-    pub fn release_slot(&self, agent_id: &str, last_update: SystemTime) -> Result<bool> {
-        self.with_agents_write(|agents| {
+    pub fn release_slot(&self, agent_id: &str, last_update_from_context: SystemTime) -> Result<bool> {
+        let mut needs_integrity_restore = false;
+        let successful_release = self.with_agents_write(|agents| {
             if let Some(peer) = agents.iter_mut().find(|p| p.agent_id == agent_id) {
-                if peer.last_update < last_update {
-                    // edge case, but no need to update anything anyway
-                    return Ok(false);
+                if peer.last_update > last_update_from_context {
+                    log::warn!(
+                        "Peer {} (Agent ID: {}): Was updated after selection (pool_time: {:?}, selection_time: {:?}). Skipping relative slot release, trusting agent update.",
+                        peer.external_llamacpp_addr,
+                        peer.agent_id,
+                        peer.last_update,
+                        last_update_from_context
+                    );
+                    Ok(false)
+                } else {
+                    if peer.release_slot() {
+                        Ok(true)
+                    } else {
+                        log::warn!(
+                            "Peer {} (Agent ID: {}): peer.release_slot() returned false. State might be inconsistent (e.g. slots_processing was 0).",
+                            peer.external_llamacpp_addr,
+                            peer.agent_id
+                        );
+                        needs_integrity_restore = true;
+                        Ok(false)
+                    }
                 }
-
-                peer.release_slot();
-
-                return Ok(true);
+            } else {
+                Ok(false)
             }
+        })?;
 
-            Ok(false)
-        })
+        if needs_integrity_restore {
+            self.restore_integrity()?;
+        }
+        Ok(successful_release)
     }
 
     pub fn remove_peer(&self, agent_id: &str) -> Result<()> {
@@ -90,15 +122,29 @@ impl UpstreamPeerPool {
     }
 
     pub fn take_slot(&self, agent_id: &str) -> Result<bool> {
-        self.with_agents_write(|agents| {
+        let mut needs_integrity_restore = false;
+        let successful_take = self.with_agents_write(|agents| {
             if let Some(peer) = agents.iter_mut().find(|p| p.agent_id == agent_id) {
-                peer.take_slot();
-
-                Ok(true)
+                if peer.take_slot() {
+                    Ok(true)
+                } else {
+                    log::warn!(
+                        "Peer {} (Agent ID: {}): peer.take_slot() returned false. Peer might have no idle slots.",
+                        peer.external_llamacpp_addr,
+                        peer.agent_id
+                    );
+                    needs_integrity_restore = true;
+                    Ok(false)
+                }
             } else {
                 Ok(false)
             }
-        })
+        })?;
+
+        if needs_integrity_restore {
+            self.restore_integrity()?;
+        }
+        Ok(successful_take)
     }
 
     #[cfg(feature = "statsd_reporter")]
@@ -131,7 +177,7 @@ impl UpstreamPeerPool {
 
     #[cfg(feature = "statsd_reporter")]
     #[inline]
-    fn with_agents_read<TCallback, TResult>(&self, cb: TCallback) -> Result<TResult>
+    pub fn with_agents_read<TCallback, TResult>(&self, cb: TCallback) -> Result<TResult>
     where
         TCallback: FnOnce(&Vec<UpstreamPeer>) -> Result<TResult>,
     {
@@ -142,7 +188,7 @@ impl UpstreamPeerPool {
     }
 
     #[inline]
-    fn with_agents_write<TCallback, TResult>(&self, cb: TCallback) -> Result<TResult>
+    pub fn with_agents_write<TCallback, TResult>(&self, cb: TCallback) -> Result<TResult>
     where
         TCallback: FnOnce(&mut Vec<UpstreamPeer>) -> Result<TResult>,
     {
@@ -150,5 +196,198 @@ impl UpstreamPeerPool {
             Ok(mut agents) => cb(&mut agents),
             Err(_) => Err("Failed to acquire write lock".into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    fn create_test_peer(id: &str, idle: usize, processing: usize) -> UpstreamPeer {
+        UpstreamPeer::new(
+            id.to_string(),
+            Some(format!("test_{}", id)),
+            None,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
+            Some(true),
+            Some(true),
+            idle,
+            processing,
+        )
+    }
+
+    #[test]
+    fn test_take_slot_success() {
+        let pool = UpstreamPeerPool::new();
+        let peer = create_test_peer("test1", 5, 0);
+        
+        pool.with_agents_write(|agents| {
+            agents.push(peer);
+            Ok(())
+        }).unwrap();
+
+        assert!(pool.take_slot("test1").unwrap());
+        
+        pool.with_agents_read(|agents| {
+            let peer = agents.iter().find(|p| p.agent_id == "test1").unwrap();
+            assert_eq!(peer.slots_idle, 4);
+            assert_eq!(peer.slots_processing, 1);
+            Ok(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_take_slot_prevents_underflow() {
+        let pool = UpstreamPeerPool::new();
+        let peer = create_test_peer("test1", 0, 0); // No idle slots
+        pool.with_agents_write(|agents| {
+            agents.push(peer);
+            Ok(())
+        }).unwrap();
+        // This should fail gracefully, not underflow
+        assert!(!pool.take_slot("test1").unwrap());
+        pool.with_agents_read(|agents| {
+            let peer = agents.iter().find(|p| p.agent_id == "test1").unwrap();
+            assert_eq!(peer.slots_idle, 0); // Should remain 0
+            assert_eq!(peer.slots_processing, 0); // Should remain 0
+            Ok(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_take_slot_failure() {
+        let pool = UpstreamPeerPool::new();
+        let peer = create_test_peer("test1", 0, 0);
+        
+        pool.with_agents_write(|agents| {
+            agents.push(peer);
+            Ok(())
+        }).unwrap();
+
+        assert!(!pool.take_slot("test1").unwrap());
+        
+        pool.with_agents_read(|agents| {
+            let peer = agents.iter().find(|p| p.agent_id == "test1").unwrap();
+            assert_eq!(peer.slots_idle, 0);
+            assert_eq!(peer.slots_processing, 0);
+            Ok(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_release_slot_success() {
+        let pool = UpstreamPeerPool::new();
+        let peer = create_test_peer("test1", 4, 1);
+        
+        pool.with_agents_write(|agents| {
+            agents.push(peer);
+            Ok(())
+        }).unwrap();
+
+        assert!(pool.take_slot("test1").unwrap());
+        
+        let last_update_at_selection_time = pool.with_agents_read(|agents| {
+            Ok(agents.iter().find(|p| p.agent_id == "test1").unwrap().last_update)
+        }).unwrap();
+        
+        assert!(pool.release_slot("test1", last_update_at_selection_time).unwrap());
+        
+        pool.with_agents_read(|agents| {
+            let peer = agents.iter().find(|p| p.agent_id == "test1").unwrap();
+            assert_eq!(peer.slots_idle, 4, "Idle slots should be 4 after take and release");
+            assert_eq!(peer.slots_processing, 1, "Processing slots should be 1 after take and release");
+            Ok(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_release_slot_prevents_underflow() {
+        let pool = UpstreamPeerPool::new();
+        let peer = create_test_peer("test1", 5, 0); // No processing slots
+        pool.with_agents_write(|agents| {
+            agents.push(peer);
+            Ok(())
+        }).unwrap();
+        // This should fail gracefully, not underflow
+        assert!(!pool.release_slot("test1", SystemTime::now()).unwrap());
+        pool.with_agents_read(|agents| {
+            let peer = agents.iter().find(|p| p.agent_id == "test1").unwrap();
+            assert_eq!(peer.slots_idle, 5); // Should remain 5
+            assert_eq!(peer.slots_processing, 0); // Should remain 0
+            Ok(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_release_slot_failure() {
+        let pool = UpstreamPeerPool::new();
+        let peer = create_test_peer("test1", 5, 0);
+        
+        pool.with_agents_write(|agents| {
+            agents.push(peer);
+            Ok(())
+        }).unwrap();
+
+        assert!(!pool.release_slot("test1", SystemTime::now()).unwrap());
+        
+        pool.with_agents_read(|agents| {
+            let peer = agents.iter().find(|p| p.agent_id == "test1").unwrap();
+            assert_eq!(peer.slots_idle, 5);
+            assert_eq!(peer.slots_processing, 0);
+            Ok(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_race_condition_handling() {
+        let pool = UpstreamPeerPool::new();
+        let peer = create_test_peer("test1", 5, 0);
+        
+        pool.with_agents_write(|agents| {
+            agents.push(peer);
+            Ok(())
+        }).unwrap();
+
+        assert!(pool.take_slot("test1").unwrap());
+
+        let last_update_at_selection_time = pool.with_agents_read(|agents| {
+            Ok(agents.iter().find(|p| p.agent_id == "test1").unwrap().last_update)
+        }).unwrap();
+
+        let status_update = StatusUpdate::new(
+            Some("test1".to_string()),
+            None,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
+            Some(true),
+            Some(true),
+            vec![],
+        );
+        pool.register_status_update("test1", status_update).unwrap();
+
+        assert!(!pool.release_slot("test1", last_update_at_selection_time).unwrap());
+        
+        pool.with_agents_read(|agents| {
+            let peer = agents.iter().find(|p| p.agent_id == "test1").unwrap();
+            assert_eq!(peer.slots_idle, 0, "Idle slots should be 0 after status update");
+            assert_eq!(peer.slots_processing, 0, "Processing slots should be 0 after status update");
+            Ok(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_use_best_peer() {
+        let pool = UpstreamPeerPool::new();
+        
+        pool.with_agents_write(|agents| {
+            agents.push(create_test_peer("test1", 5, 0));
+            agents.push(create_test_peer("test2", 3, 0));
+            agents.push(create_test_peer("test3", 0, 0));
+            Ok(())
+        }).unwrap();
+
+        let best_peer = pool.use_best_peer().unwrap().unwrap();
+        assert_eq!(best_peer.agent_id, "test1");
+        assert_eq!(best_peer.slots_idle, 5);
     }
 }


### PR DESCRIPTION
**Closes #56**

Hey team! This PR fixes a race condition in Paddler’s slot accounting for llama.cpp peers (Issue #56). The issue occurs when agent status updates (absolute slot counts) clash with the balancer’s take_slot/release_slot adjustments, potentially causing `slots_idle` or `slots_processing` to underflow to `usize::MAX`. This messes up peer states and load balancing.

### Changes

### UpstreamPeer (`src/balancer/upstream_peer.rs`):

- Updated `take_slot` and `release_slot` to check slot counts before changes and return a bool for success/failure.
- Added logging for failed slot operations.

### UpstreamPeerPool (`src/balancer/upstream_peer_pool.rs`):

- Uses boolean results from UpstreamPeer methods.
- Added `needs_integrity_restore` flag to call `restore_integrity` after releasing `RwLock` write guard, avoiding deadlocks.
- Improved `release_slot` to skip relative updates if an agent’s `last_update` is newer, prioritizing absolute state.

### ProxyService (`src/balancer/proxy_service.rs`):

- Sets `ctx.slot_taken` to true only if a slot is successfully taken.
- Retry logic for `take_slot` now respects pool operation outcomes.

### Unit Tests

- Added tests in `upstream_peer.rs`, `upstream_peer_pool.rs`, and `proxy_service.rs` to verify fixes.

### Tests in `upstream_peer.rs`
- `test_take_slot_success` / `test_take_slot_failure`: Verify slot can only be taken when idle slots are available, and fails otherwise.
- `test_release_slot_success` / `test_release_slot_failure`: Verify slot can only be released when processing slots are present, and fails otherwise.
- `test_update_status`: Checks that absolute status updates correctly set slot counts.

### Tests in `upstream_peer_pool.rs`
- `test_take_slot_success`: Peer pool allows taking a slot when possible.
- `test_take_slot_prevents_underflow`: Ensures no underflow when `slots_idle == 0`.
- `test_take_slot_failure`: Fails to take slot when none are idle.
- `test_release_slot_success`: Peer pool allows releasing a slot when possible.
- `test_release_slot_prevents_underflow`: Ensures no underflow when `slots_processing == 0`.
- `test_release_slot_failure`: Fails to release slot when none are processing.
- `test_race_condition_handling`: Simulates agent status update vs. balancer race; ensures absolute update wins and prevents invalid relative changes.
- `test_use_best_peer`: Verifies peer selection logic remains correct with new slot accounting.

### Tests in `proxy_service.rs`
- `test_take_slot_success`: Confirms context marks slot as taken only on success.
- `test_take_slot_failure_and_retry`: Ensures retry logic works when initial slot take fails.
- `test_release_slot_success`: Confirms context releases slot and updates state on success.
- `test_release_slot_failure`: Ensures failed release does not corrupt state.

These tests collectively verify slot operation success/failure, underflow prevention, and correct handling of race conditions between absolute and relative updates.

### Impact

These changes make Paddler’s peer state management more robust, preventing bad load balancing from corrupted slot counts.

### Verification

Run `cargo test` to confirm all tests pass.

### Note to Maintainers

I added unit tests directly in the implementation files to verify the fixes. If this doesn’t match your repo’s conventions, feel free to move them to a `tests/` directory or let me know if I can help with that. Happy to contribute — solid project. 😄
