### PR TITLE
typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ fmt: node_modules
 	./jarmuz-fmt.mjs
 	$(MAKE) -C integration_tests fmt
 
-.PHONY: integration_tests
-integration_tests:
+.PHONY: test.integration
+test.integration:
 	cargo build
 	$(MAKE) -C integration_tests test
 

--- a/src/balancer/buffered_request_manager.rs
+++ b/src/balancer/buffered_request_manager.rs
@@ -11,7 +11,7 @@ use crate::balancer::buffered_request_count_guard::BufferedRequestCountGuard;
 
 pub struct BufferedRequestManager {
     agent_controller_pool: Arc<AgentControllerPool>,
-    buffered_request_timeout: Duration,
+    request_timeout: Duration,
     pub buffered_requests_count: Arc<AtomicValue>,
     max_buffered_requests: i32,
 }
@@ -19,12 +19,12 @@ pub struct BufferedRequestManager {
 impl BufferedRequestManager {
     pub fn new(
         agent_controller_pool: Arc<AgentControllerPool>,
-        buffered_request_timeout: Duration,
+        request_timeout: Duration,
         max_buffered_requests: i32,
     ) -> Self {
         Self {
             agent_controller_pool,
-            buffered_request_timeout,
+            request_timeout,
             buffered_requests_count: Arc::new(AtomicValue::new(0)),
             max_buffered_requests,
         }
@@ -41,7 +41,7 @@ impl BufferedRequestManager {
         let _buffered_request_count_guard =
             BufferedRequestCountGuard::new(self.buffered_requests_count.clone());
 
-        match timeout(self.buffered_request_timeout, async {
+        match timeout(self.request_timeout, async {
             loop {
                 match agent_controller_pool.find_least_busy_agent_controller() {
                     Some(agent_controller) => {

--- a/src/cmd/agent.rs
+++ b/src/cmd/agent.rs
@@ -21,11 +21,11 @@ use crate::service_manager::ServiceManager;
 #[derive(Parser)]
 pub struct Agent {
     #[arg(long, value_parser = parse_socket_addr)]
-    /// Address of the management server that the agent will report to
+    /// Address of the management server that the agent will report to.
     management_addr: SocketAddr,
 
     #[arg(long)]
-    /// Name of the agent (optional)
+    /// Name of the agent (optional).
     name: Option<String>,
 
     #[arg(long)]

--- a/src/cmd/balancer.rs
+++ b/src/cmd/balancer.rs
@@ -34,10 +34,10 @@ pub struct Balancer {
     #[arg(long, default_value = "10000", value_parser = parse_duration)]
     /// The request timeout (in milliseconds). For all requests that a timely response from an
     /// upstream isn't received for, the 504 (Gateway Timeout) error is issued.
-    buffered_request_timeout: Duration,
+    request_timeout: Duration,
 
     #[arg(long, default_value = "127.0.0.1:8061", value_parser = parse_socket_addr)]
-    /// Address of the inference server
+    /// Address of the inference server.
     inference_addr: SocketAddr,
 
     #[arg(long, default_value = "10000", value_parser = parse_duration)]
@@ -48,18 +48,18 @@ pub struct Balancer {
         long = "inference-cors-allowed-host",
         action = clap::ArgAction::Append
     )]
-    /// Allowed CORS host (can be specified multiple times)
+    /// Allowed CORS host (can be specified multiple times).
     inference_cors_allowed_hosts: Vec<String>,
 
     #[arg(long, default_value = "127.0.0.1:8060", value_parser = parse_socket_addr)]
-    /// Address of the management server that the balancer will report to
+    /// Address of the management server that the balancer will report to.
     management_addr: SocketAddr,
 
     #[arg(
         long = "management-cors-allowed-host",
         action = clap::ArgAction::Append
     )]
-    /// Allowed CORS host (can be specified multiple times)
+    /// Allowed CORS host (can be specified multiple times).
     management_cors_allowed_hosts: Vec<String>,
 
     #[arg(long, default_value = "30")]
@@ -69,23 +69,23 @@ pub struct Balancer {
     max_buffered_requests: i32,
 
     #[arg(long, default_value = "memory://")]
-    /// Balancer state database URL. Supported: memory, memory://, or file:///path (optional)
+    /// Balancer state database URL. Supported: memory, memory://, or file:///path (optional).
     state_database: DatabaseType,
 
     #[arg(long, value_parser = parse_socket_addr)]
-    /// Address of the statsd server to report metrics to
+    /// Address of the statsd server to report metrics to.
     statsd_addr: Option<SocketAddr>,
 
     #[arg(long, default_value = "paddler")]
-    /// Prefix for statsd metrics
+    /// Prefix for statsd metrics.
     statsd_prefix: String,
 
     #[arg(long, default_value = "10000", value_parser = parse_duration)]
-    /// Interval (in milliseconds) at which the balancer will report metrics to statsd
+    /// Interval (in milliseconds) at which the balancer will report metrics to statsd.
     statsd_reporting_interval: Duration,
 
     #[arg(long, default_value = None, value_parser = parse_socket_addr)]
-    /// Address of the web management dashboard (if enabled)
+    /// Address of the web management dashboard (if enabled).
     web_admin_panel_addr: Option<SocketAddr>,
 }
 
@@ -116,7 +116,7 @@ impl Handler for Balancer {
         let agent_controller_pool = Arc::new(AgentControllerPool::new());
         let buffered_request_manager = Arc::new(BufferedRequestManager::new(
             agent_controller_pool.clone(),
-            self.buffered_request_timeout,
+            self.request_timeout,
             self.max_buffered_requests,
         ));
         let generate_tokens_sender_collection = Arc::new(GenerateTokensSenderCollection::new());


### PR DESCRIPTION
docs miss some periods, also:
[documentation](https://github.com/distantmagic/paddler/blob/a6c63b93ce8db70e154b02d27795a5cce54c63e6/src/cmd/balancer.rs#L65-L68) for `max_buffered_requests` and [https://github.com/distantmagic/paddler/blob/a6c63b93ce8db70e154b02d27795a5cce54c63e6/src/cmd/balancer.rs#L35-L36](buffered_request_timeout) show that this timeout applies for all requests:
>The request timeout (in milliseconds). For all requests [...]
>Like with usual requests, the request timeout
>is also applied to buffered ones.

so i am renaming the field.