### PR TITLE
Change stream parameter optional in openai compatible api

### DIFF
--- a/src/balancer/compatibility/openai_service/http_route/post_chat_completions.rs
+++ b/src/balancer/compatibility/openai_service/http_route/post_chat_completions.rs
@@ -58,7 +58,7 @@ struct OpenAICompletionRequestParams {
     messages: Vec<OpenAIMessage>,
     /// This parameter is ignored here, but is required by the OpenAI API.
     model: String,
-    stream: bool,
+    stream: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -166,7 +166,7 @@ async fn respond(
         tools: vec![],
     };
 
-    if openai_params.stream {
+    if openai_params.stream.unwrap_or(false) {
         http_stream_from_agent(
             app_data.buffered_request_manager.clone(),
             app_data.inference_service_configuration.clone(),


### PR DESCRIPTION
Thanks for sharing this great project to public.

I tried to use paddler serve `immersivetranslate` chrome extention local api backend. Then I found the request is broken at `stream` field is missing.  After changing it to optional, everything work as charm.