### PR TITLE
Change the default models list in the GUI app

### DIFF
--- a/paddler_gui/src/available_model_presets.rs
+++ b/paddler_gui/src/available_model_presets.rs
@@ -1,0 +1,10 @@
+use crate::model_preset::ModelPreset;
+use crate::model_preset_qwen3_0_6b;
+use crate::model_preset_qwen3_5_0_8b;
+
+pub fn available_model_presets() -> Vec<ModelPreset> {
+    vec![
+        model_preset_qwen3_0_6b::preset(),
+        model_preset_qwen3_5_0_8b::preset(),
+    ]
+}

--- a/paddler_gui/src/main.rs
+++ b/paddler_gui/src/main.rs
@@ -1,6 +1,7 @@
 mod agent_running_data;
 mod agent_running_handler;
 mod app;
+mod available_model_presets;
 mod current_screen;
 mod detect_network_interfaces;
 mod home_data;
@@ -9,6 +10,8 @@ mod join_balancer_form_data;
 mod join_balancer_form_handler;
 mod message;
 mod model_preset;
+mod model_preset_qwen3_0_6b;
+mod model_preset_qwen3_5_0_8b;
 mod network_interface_address;
 mod running_balancer_data;
 mod running_balancer_handler;

--- a/paddler_gui/src/model_preset.rs
+++ b/paddler_gui/src/model_preset.rs
@@ -14,35 +14,6 @@ pub struct ModelPreset {
 }
 
 impl ModelPreset {
-    pub fn available_presets() -> Vec<Self> {
-        vec![
-            Self {
-                display_name: "Qwen 3 0.6B".to_owned(),
-                model: HuggingFaceModelReference {
-                    repo_id: "unsloth/Qwen3-0.6B-GGUF".to_owned(),
-                    filename: "Qwen3-0.6B-Q8_0.gguf".to_owned(),
-                    revision: "main".to_owned(),
-                },
-                multimodal_projection: None,
-                inference_parameters: InferenceParameters::default(),
-            },
-            Self {
-                display_name: "Qwen 3.5 0.8B".to_owned(),
-                model: HuggingFaceModelReference {
-                    repo_id: "unsloth/Qwen3.5-0.8B-GGUF".to_owned(),
-                    filename: "Qwen3.5-0.8B-Q4_K_M.gguf".to_owned(),
-                    revision: "main".to_owned(),
-                },
-                multimodal_projection: Some(HuggingFaceModelReference {
-                    repo_id: "unsloth/Qwen3.5-0.8B-GGUF".to_owned(),
-                    filename: "mmproj-F16.gguf".to_owned(),
-                    revision: "main".to_owned(),
-                }),
-                inference_parameters: InferenceParameters::default(),
-            },
-        ]
-    }
-
     pub fn to_balancer_desired_state(&self) -> BalancerDesiredState {
         let multimodal_projection = self
             .multimodal_projection

--- a/paddler_gui/src/model_preset_qwen3_0_6b.rs
+++ b/paddler_gui/src/model_preset_qwen3_0_6b.rs
@@ -1,0 +1,17 @@
+use paddler_types::huggingface_model_reference::HuggingFaceModelReference;
+use paddler_types::inference_parameters::InferenceParameters;
+
+use crate::model_preset::ModelPreset;
+
+pub fn preset() -> ModelPreset {
+    ModelPreset {
+        display_name: "Qwen 3 0.6B".to_owned(),
+        model: HuggingFaceModelReference {
+            repo_id: "unsloth/Qwen3-0.6B-GGUF".to_owned(),
+            filename: "Qwen3-0.6B-Q8_0.gguf".to_owned(),
+            revision: "main".to_owned(),
+        },
+        multimodal_projection: None,
+        inference_parameters: InferenceParameters::default(),
+    }
+}

--- a/paddler_gui/src/model_preset_qwen3_5_0_8b.rs
+++ b/paddler_gui/src/model_preset_qwen3_5_0_8b.rs
@@ -1,0 +1,21 @@
+use paddler_types::huggingface_model_reference::HuggingFaceModelReference;
+use paddler_types::inference_parameters::InferenceParameters;
+
+use crate::model_preset::ModelPreset;
+
+pub fn preset() -> ModelPreset {
+    ModelPreset {
+        display_name: "Qwen 3.5 0.8B".to_owned(),
+        model: HuggingFaceModelReference {
+            repo_id: "unsloth/Qwen3.5-0.8B-GGUF".to_owned(),
+            filename: "Qwen3.5-0.8B-Q4_K_M.gguf".to_owned(),
+            revision: "main".to_owned(),
+        },
+        multimodal_projection: Some(HuggingFaceModelReference {
+            repo_id: "unsloth/Qwen3.5-0.8B-GGUF".to_owned(),
+            filename: "mmproj-F16.gguf".to_owned(),
+            revision: "main".to_owned(),
+        }),
+        inference_parameters: InferenceParameters::default(),
+    }
+}

--- a/paddler_gui/src/ui/view_start_balancer_form.rs
+++ b/paddler_gui/src/ui/view_start_balancer_form.rs
@@ -25,12 +25,12 @@ use super::variables::SPACING_2X;
 use super::variables::SPACING_BASE;
 use super::variables::SPACING_HALF;
 use super::view_form_field::view_form_field;
-use crate::model_preset::ModelPreset;
+use crate::available_model_presets::available_model_presets;
 use crate::start_balancer_form_data::StartBalancerFormData;
 use crate::start_balancer_form_handler::Message;
 
 pub fn view_start_balancer_form(data: &StartBalancerFormData) -> Element<'_, Message> {
-    let available_models = ModelPreset::available_presets();
+    let available_models = available_model_presets();
 
     let confirm_button = if data.starting {
         button(text("Starting...").font(BOLD))


### PR DESCRIPTION
The goal is to have something scalable that will allow us to add more model presets to Paddler's desktop app. I also want to make sure it's easy to set up custom inference parameters per model (and that's the reason for having separate preset files for each model).