### PR TITLE
Add Metal integration test target and fix Metal-incompatible test data

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: build the cli binary
-        run: make release
+        run: make target/release/paddler
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
         shell: bash
 
       - name: build the gui binary
-        run: make release.gui
+        run: make target/release/paddler_gui
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-.DEFAULT_GOAL := release
+.DEFAULT_GOAL := target/release/paddler
 
 RUST_LOG ?= debug
+
+PADDLER_CLI_SOURCES := $(shell find paddler/src paddler_bootstrap/src paddler_cli/src paddler_client/src paddler_types/src -name '*.rs')
+PADDLER_GUI_SOURCES := $(shell find paddler/src paddler_bootstrap/src paddler_gui/src paddler_types/src -name '*.rs')
+FRONTEND_SOURCES := $(shell find resources -type f) $(wildcard jarmuz/*.mjs)
 
 # -----------------------------------------------------------------------------
 # Real targets
@@ -13,8 +17,32 @@ node_modules: package-lock.json
 	npm ci
 	touch node_modules
 
-target/debug/paddler: $(shell find paddler/src paddler_bootstrap/src paddler_cli/src paddler_client/src paddler_types/src -name '*.rs')
+esbuild-meta.json: $(FRONTEND_SOURCES) jarmuz-static.mjs tsconfig.json package.json node_modules
+	./jarmuz-static.mjs
+
+target/debug/paddler: $(PADDLER_CLI_SOURCES)
 	cargo build -p paddler_cli
+
+target/release/paddler: $(PADDLER_CLI_SOURCES) esbuild-meta.json
+	cargo build --release -p paddler_cli --features web_admin_panel
+
+target/cuda/debug/paddler: $(PADDLER_CLI_SOURCES) esbuild-meta.json
+	cargo build -p paddler_cli --features cuda,web_admin_panel --target-dir target/cuda
+
+target/cuda/release/paddler: $(PADDLER_CLI_SOURCES) esbuild-meta.json
+	cargo build --release -p paddler_cli --features cuda,web_admin_panel --target-dir target/cuda
+
+target/metal/debug/paddler: $(PADDLER_CLI_SOURCES) esbuild-meta.json
+	cargo build -p paddler_cli --features metal,web_admin_panel --target-dir target/metal
+
+target/metal/release/paddler: $(PADDLER_CLI_SOURCES) esbuild-meta.json
+	cargo build --release -p paddler_cli --features metal,web_admin_panel --target-dir target/metal
+
+target/vulkan/release/paddler: $(PADDLER_CLI_SOURCES) esbuild-meta.json
+	cargo build --release -p paddler_cli --features vulkan,web_admin_panel --target-dir target/vulkan
+
+target/release/paddler_gui: $(PADDLER_GUI_SOURCES) esbuild-meta.json
+	cargo build --release -p paddler_gui --features web_admin_panel
 
 # -----------------------------------------------------------------------------
 # Phony targets
@@ -28,58 +56,30 @@ clean:
 	rm -rf target
 
 .PHONY: clippy
-clippy: frontend
+clippy: esbuild-meta.json
 	cargo clippy --workspace --all-targets --features web_admin_panel,tests_that_use_llms,tests_that_use_compiled_paddler
 
 .PHONY: fmt
 fmt: node_modules
 	./jarmuz-fmt.mjs
 
-.PHONY: frontend
-frontend: node_modules
-	./jarmuz-static.mjs
-
-.PHONY: build
-build: frontend
-	cargo build -p paddler_cli --features web_admin_panel
-
-.PHONY: build.cuda
-build.cuda: frontend
-	cargo build -p paddler_cli --features cuda,web_admin_panel
-
-.PHONY: release
-release: frontend
-	cargo build --release -p paddler_cli --features web_admin_panel
-
-.PHONY: release.cuda
-release.cuda: frontend
-	cargo build --release -p paddler_cli --features web_admin_panel,cuda
-
-.PHONY: release.vulkan
-release.vulkan: frontend
-	cargo build --release -p paddler_cli --features web_admin_panel,vulkan
-
-.PHONY: release.gui
-release.gui: frontend
-	cargo build --release -p paddler_gui --features web_admin_panel
-
 .PHONY: test
 test: test.unit test.integration
 
 .PHONY: test.integration
-test.integration:
+test.integration: target/debug/paddler
 	cargo test -p paddler_tests --features tests_that_use_compiled_paddler,tests_that_use_llms
 
 .PHONY: test.integration.cuda
-test.integration.cuda:
-	PADDLER_TEST_DEVICE=cuda cargo test -p paddler_tests --features cuda,tests_that_use_compiled_paddler,tests_that_use_llms
+test.integration.cuda: target/cuda/debug/paddler
+	PADDLER_BINARY_PATH=../target/cuda/debug/paddler PADDLER_TEST_DEVICE=cuda cargo test -p paddler_tests --features cuda,tests_that_use_compiled_paddler,tests_that_use_llms
 
 .PHONY: test.integration.metal
-test.integration.metal:
-	PADDLER_TEST_DEVICE=metal cargo test -p paddler_tests --features metal,tests_that_use_compiled_paddler,tests_that_use_llms
+test.integration.metal: target/metal/debug/paddler
+	PADDLER_BINARY_PATH=../target/metal/debug/paddler PADDLER_TEST_DEVICE=metal cargo test -p paddler_tests --features metal,tests_that_use_compiled_paddler,tests_that_use_llms
 
 .PHONY: test.unit
-test.unit: frontend
+test.unit: esbuild-meta.json
 	cargo test --features web_admin_panel
 
 .PHONY: watch

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ test.integration:
 test.integration.cuda:
 	PADDLER_TEST_DEVICE=cuda cargo test -p paddler_tests --features cuda,tests_that_use_compiled_paddler,tests_that_use_llms
 
+.PHONY: test.integration.metal
+test.integration.metal:
+	PADDLER_TEST_DEVICE=metal cargo test -p paddler_tests --features metal,tests_that_use_compiled_paddler,tests_that_use_llms
+
 .PHONY: test.unit
 test.unit: frontend
 	cargo test --features web_admin_panel

--- a/paddler/src/agent/continuous_batch_arbiter.rs
+++ b/paddler/src/agent/continuous_batch_arbiter.rs
@@ -20,6 +20,7 @@ use log::info;
 use paddler_types::agent_issue::AgentIssue;
 use paddler_types::agent_issue_params::ChatTemplateDoesNotCompileParams;
 use paddler_types::agent_issue_params::ModelPath;
+use paddler_types::agent_issue_params::SlotCannotStartParams;
 use paddler_types::chat_template::ChatTemplate;
 use paddler_types::inference_parameters::InferenceParameters;
 use paddler_types::model_metadata::ModelMetadata;
@@ -274,7 +275,28 @@ impl ContinuousBatchArbiter {
                 model: model.clone(),
             });
 
-            let llama_context = model.new_context(&llama_backend, context_params)?;
+            let llama_context = match model
+                .new_context(&llama_backend, context_params)
+                .context("Unable to create llama.cpp context")
+            {
+                Ok(context) => context,
+                Err(err) => {
+                    for slot_index in 0..desired_slots_total {
+                        #[expect(
+                            clippy::cast_sign_loss,
+                            reason = "slot_index is always non-negative"
+                        )]
+                        slot_aggregated_status_manager
+                            .slot_aggregated_status
+                            .register_issue(AgentIssue::SlotCannotStart(SlotCannotStartParams {
+                                error: format!("{err:#}"),
+                                slot_index: slot_index as u32,
+                            }));
+                    }
+
+                    return Err(err);
+                }
+            };
 
             for slot_index in 0..desired_slots_total {
                 slot_aggregated_status_manager

--- a/paddler/src/agent/llamacpp_arbiter_service.rs
+++ b/paddler/src/agent/llamacpp_arbiter_service.rs
@@ -219,6 +219,7 @@ impl Service for LlamaCppArbiterService {
 
         let shutdown_outcome = loop {
             tokio::select! {
+                biased;
                 () = shutdown.cancelled() => break Ok(()),
                 _ = ticker.tick() => {
                     let current_status = self.slot_aggregated_status_manager.slot_aggregated_status.get_state_application_status()?;
@@ -245,41 +246,20 @@ impl Service for LlamaCppArbiterService {
 
                     self.try_to_apply_state(&shutdown).await;
                 }
-                continue_from_conversation_history_request = self.continue_from_conversation_history_request_rx.recv() => {
-                    match continue_from_conversation_history_request {
-                        Some(request) => {
-                            self.forward_command(
-                                ContinuousBatchSchedulerCommand::ContinueFromConversationHistory(request),
-                            );
-                        }
-                        None => {
-                            break Err(anyhow!("ContinueFromConversationHistoryRequest channel closed unexpectedly"));
-                        }
-                    }
+                Some(request) = self.continue_from_conversation_history_request_rx.recv() => {
+                    self.forward_command(
+                        ContinuousBatchSchedulerCommand::ContinueFromConversationHistory(request),
+                    );
                 }
-                continue_from_raw_prompt_request = self.continue_from_raw_prompt_request_rx.recv() => {
-                    match continue_from_raw_prompt_request {
-                        Some(request) => {
-                            self.forward_command(
-                                ContinuousBatchSchedulerCommand::ContinueFromRawPrompt(request),
-                            );
-                        }
-                        None => {
-                            break Err(anyhow!("ContinueFromRawPromptRequest channel closed unexpectedly"));
-                        }
-                    }
+                Some(request) = self.continue_from_raw_prompt_request_rx.recv() => {
+                    self.forward_command(
+                        ContinuousBatchSchedulerCommand::ContinueFromRawPrompt(request),
+                    );
                 }
-                generate_embedding_batch_request = self.generate_embedding_batch_request_rx.recv() => {
-                    match generate_embedding_batch_request {
-                        Some(request) => {
-                            self.forward_command(
-                                ContinuousBatchSchedulerCommand::GenerateEmbeddingBatch(request),
-                            );
-                        }
-                        None => {
-                            break Err(anyhow!("GenerateEmbeddingBatchRequest channel closed unexpectedly"));
-                        }
-                    }
+                Some(request) = self.generate_embedding_batch_request_rx.recv() => {
+                    self.forward_command(
+                        ContinuousBatchSchedulerCommand::GenerateEmbeddingBatch(request),
+                    );
                 }
             }
         };
@@ -289,5 +269,68 @@ impl Service for LlamaCppArbiterService {
         }
 
         shutdown_outcome
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::bail;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn does_not_exit_when_request_channels_close_without_shutdown() -> Result<()> {
+        let observation_window = Duration::from_millis(500);
+        let shutdown_grace = Duration::from_secs(5);
+
+        let (
+            continue_from_conversation_history_request_tx,
+            continue_from_conversation_history_request_rx,
+        ) = mpsc::unbounded_channel();
+        let (continue_from_raw_prompt_request_tx, continue_from_raw_prompt_request_rx) =
+            mpsc::unbounded_channel();
+        let (generate_embedding_batch_request_tx, generate_embedding_batch_request_rx) =
+            mpsc::unbounded_channel();
+
+        let mut service = LlamaCppArbiterService {
+            agent_applicable_state: None,
+            agent_applicable_state_holder: Arc::new(AgentApplicableStateHolder::default()),
+            agent_name: None,
+            continue_from_conversation_history_request_rx,
+            continue_from_raw_prompt_request_rx,
+            desired_slots_total: 1,
+            generate_embedding_batch_request_rx,
+            continuous_batch_arbiter_handle: None,
+            model_metadata_holder: Arc::new(ModelMetadataHolder::default()),
+            slot_aggregated_status_manager: Arc::new(SlotAggregatedStatusManager::new(1)),
+        };
+
+        let shutdown = CancellationToken::new();
+        let task_token = shutdown.clone();
+
+        let mut join_handle = tokio::spawn(async move { service.run(task_token).await });
+
+        drop(continue_from_conversation_history_request_tx);
+        drop(continue_from_raw_prompt_request_tx);
+        drop(generate_embedding_batch_request_tx);
+
+        let exited_before_shutdown = tokio::select! {
+            join_result = &mut join_handle => Some(join_result),
+            () = tokio::time::sleep(observation_window) => None,
+        };
+
+        if let Some(join_result) = exited_before_shutdown {
+            let inner = join_result.context("service task panicked")?;
+            bail!("service exited on channel closure without shutdown: {inner:?}");
+        }
+
+        shutdown.cancel();
+
+        tokio::time::timeout(shutdown_grace, join_handle)
+            .await
+            .context("service did not exit after shutdown")?
+            .context("service task panicked")??;
+
+        Ok(())
     }
 }

--- a/paddler_cli/Cargo.toml
+++ b/paddler_cli/Cargo.toml
@@ -34,6 +34,7 @@ workspace = true
 [features]
 default = []
 cuda = ["paddler/cuda"]
+metal = ["paddler/metal"]
 vulkan = ["paddler/vulkan"]
 web_admin_panel = [
     "dep:esbuild-metafile",

--- a/paddler_tests/src/agents_stream_watcher.rs
+++ b/paddler_tests/src/agents_stream_watcher.rs
@@ -70,14 +70,18 @@ impl AgentsStreamWatcher {
             .await
             .context("agents did not reach the requested slot count")?;
 
-        let issues: Vec<_> = snapshot
+        let agents_with_issues: Vec<String> = snapshot
             .agents
             .iter()
-            .flat_map(|agent| agent.issues.iter().cloned())
+            .filter(|agent| !agent.issues.is_empty())
+            .map(|agent| format!("agent {}: {:?}", agent.id, agent.issues))
             .collect();
 
-        if !issues.is_empty() {
-            bail!("agents reported issues while waiting for slots: {issues:?}");
+        if !agents_with_issues.is_empty() {
+            bail!(
+                "agents reported issues while waiting for slots: {}",
+                agents_with_issues.join("; ")
+            );
         }
 
         Ok(())

--- a/paddler_tests/src/agents_stream_watcher.rs
+++ b/paddler_tests/src/agents_stream_watcher.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::anyhow;
+use anyhow::bail;
 use futures_util::Stream;
 use futures_util::StreamExt as _;
 use paddler_client::ClientManagement;
@@ -52,5 +53,33 @@ impl AgentsStreamWatcher {
         Err(anyhow!(
             "agents stream closed before predicate was satisfied"
         ))
+    }
+
+    pub async fn wait_for_slots_ready(
+        &mut self,
+        expected_agent_count: usize,
+        slots_per_agent: i32,
+    ) -> Result<()> {
+        let snapshot = self
+            .until(move |snapshot| {
+                snapshot.agents.len() >= expected_agent_count
+                    && snapshot.agents.iter().all(|agent| {
+                        agent.slots_total >= slots_per_agent || !agent.issues.is_empty()
+                    })
+            })
+            .await
+            .context("agents did not reach the requested slot count")?;
+
+        let issues: Vec<_> = snapshot
+            .agents
+            .iter()
+            .flat_map(|agent| agent.issues.iter().cloned())
+            .collect();
+
+        if !issues.is_empty() {
+            bail!("agents reported issues while waiting for slots: {issues:?}");
+        }
+
+        Ok(())
     }
 }

--- a/paddler_tests/src/start_in_process_cluster.rs
+++ b/paddler_tests/src/start_in_process_cluster.rs
@@ -109,15 +109,8 @@ pub async fn start_in_process_cluster(
 
     if wait_for_slots_ready && spawn_agent {
         agents_watcher
-            .until(move |snapshot| {
-                snapshot.agents.len() >= expected_agent_count
-                    && snapshot
-                        .agents
-                        .iter()
-                        .all(|agent| agent.slots_total >= slots_per_agent)
-            })
-            .await
-            .context("agent did not reach the requested slot count")?;
+            .wait_for_slots_ready(expected_agent_count, slots_per_agent)
+            .await?;
     }
 
     Ok(ClusterHandle::new(ClusterHandleParams {

--- a/paddler_tests/src/start_subprocess_cluster.rs
+++ b/paddler_tests/src/start_subprocess_cluster.rs
@@ -126,15 +126,8 @@ pub async fn start_subprocess_cluster(
 
     if wait_for_slots_ready {
         agents_watcher
-            .until(move |snapshot| {
-                snapshot.agents.len() >= agent_count
-                    && snapshot
-                        .agents
-                        .iter()
-                        .all(|agent| agent.slots_total >= slots_per_agent)
-            })
-            .await
-            .context("subprocess agents did not reach the requested slot count")?;
+            .wait_for_slots_ready(agent_count, slots_per_agent)
+            .await?;
     }
 
     Ok(ClusterHandle::new(ClusterHandleParams {

--- a/paddler_tests/src/test_device.rs
+++ b/paddler_tests/src/test_device.rs
@@ -43,7 +43,7 @@ impl TestDevice {
             #[cfg(feature = "cuda")]
             Self::Cuda => require_backend_device("CUDA"),
             #[cfg(feature = "metal")]
-            Self::Metal => require_backend_device("Metal"),
+            Self::Metal => require_backend_device("MTL"),
         }
     }
 

--- a/paddler_tests/tests/agent_reports_slot_cannot_start_for_excessive_slots_in_process.rs
+++ b/paddler_tests/tests/agent_reports_slot_cannot_start_for_excessive_slots_in_process.rs
@@ -1,0 +1,77 @@
+#![cfg(all(
+    feature = "tests_that_use_compiled_paddler",
+    feature = "tests_that_use_llms"
+))]
+
+use std::time::Duration;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use paddler_tests::current_test_device::current_test_device;
+use paddler_tests::in_process_cluster_params::InProcessClusterParams;
+use paddler_tests::model_card::ModelCard;
+use paddler_tests::model_card::qwen3_0_6b::qwen3_0_6b;
+use paddler_tests::start_in_process_cluster::start_in_process_cluster;
+use paddler_types::agent_desired_model::AgentDesiredModel;
+use paddler_types::agent_issue::AgentIssue;
+use paddler_types::balancer_desired_state::BalancerDesiredState;
+
+#[serial_test::file_serial(model_load, path => "../target/model_load.lock")]
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_reports_slot_cannot_start_for_excessive_slots_in_process() -> Result<()> {
+    let device = current_test_device()?;
+
+    device.require_available()?;
+
+    let ModelCard {
+        gpu_layer_count,
+        reference,
+    } = qwen3_0_6b();
+
+    let inference_parameters = device.inference_parameters_for_full_offload(gpu_layer_count);
+
+    let mut cluster = start_in_process_cluster(InProcessClusterParams {
+        spawn_agent: true,
+        slots_per_agent: 257,
+        desired_state: BalancerDesiredState {
+            chat_template_override: None,
+            inference_parameters,
+            model: AgentDesiredModel::HuggingFace(reference),
+            multimodal_projection: AgentDesiredModel::None,
+            use_chat_template_override: false,
+        },
+        wait_for_slots_ready: false,
+        ..InProcessClusterParams::default()
+    })
+    .await?;
+
+    let snapshot = tokio::time::timeout(
+        Duration::from_secs(10),
+        cluster.agents.until(|snapshot| {
+            snapshot.agents.iter().any(|agent| {
+                agent
+                    .issues
+                    .iter()
+                    .any(|issue| matches!(issue, AgentIssue::SlotCannotStart(_)))
+            })
+        }),
+    )
+    .await
+    .context("agent did not report SlotCannotStart within 10s")??;
+
+    let slot_cannot_start_count = snapshot
+        .agents
+        .iter()
+        .flat_map(|agent| agent.issues.iter())
+        .filter(|issue| matches!(issue, AgentIssue::SlotCannotStart(params) if !params.error.is_empty()))
+        .count();
+
+    assert!(
+        slot_cannot_start_count > 0,
+        "expected at least one SlotCannotStart issue with non-empty error"
+    );
+
+    cluster.shutdown().await?;
+
+    Ok(())
+}

--- a/paddler_tests/tests/agent_reports_slot_cannot_start_for_excessive_slots_subprocess.rs
+++ b/paddler_tests/tests/agent_reports_slot_cannot_start_for_excessive_slots_subprocess.rs
@@ -1,0 +1,77 @@
+#![cfg(all(
+    feature = "tests_that_use_compiled_paddler",
+    feature = "tests_that_use_llms"
+))]
+
+use std::time::Duration;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use paddler_tests::current_test_device::current_test_device;
+use paddler_tests::model_card::ModelCard;
+use paddler_tests::model_card::qwen3_0_6b::qwen3_0_6b;
+use paddler_tests::start_subprocess_cluster::start_subprocess_cluster;
+use paddler_tests::subprocess_cluster_params::SubprocessClusterParams;
+use paddler_types::agent_desired_model::AgentDesiredModel;
+use paddler_types::agent_issue::AgentIssue;
+use paddler_types::balancer_desired_state::BalancerDesiredState;
+
+#[serial_test::file_serial(model_load, path => "../target/model_load.lock")]
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_reports_slot_cannot_start_for_excessive_slots_subprocess() -> Result<()> {
+    let device = current_test_device()?;
+
+    device.require_available()?;
+
+    let ModelCard {
+        gpu_layer_count,
+        reference,
+    } = qwen3_0_6b();
+
+    let inference_parameters = device.inference_parameters_for_full_offload(gpu_layer_count);
+
+    let mut cluster = start_subprocess_cluster(SubprocessClusterParams {
+        agent_count: 1,
+        slots_per_agent: 257,
+        wait_for_slots_ready: false,
+        desired_state: Some(BalancerDesiredState {
+            chat_template_override: None,
+            inference_parameters,
+            model: AgentDesiredModel::HuggingFace(reference),
+            multimodal_projection: AgentDesiredModel::None,
+            use_chat_template_override: false,
+        }),
+        ..SubprocessClusterParams::default()
+    })
+    .await?;
+
+    let snapshot = tokio::time::timeout(
+        Duration::from_secs(10),
+        cluster.agents.until(|snapshot| {
+            snapshot.agents.iter().any(|agent| {
+                agent
+                    .issues
+                    .iter()
+                    .any(|issue| matches!(issue, AgentIssue::SlotCannotStart(_)))
+            })
+        }),
+    )
+    .await
+    .context("agent did not report SlotCannotStart within 10s")??;
+
+    let slot_cannot_start_count = snapshot
+        .agents
+        .iter()
+        .flat_map(|agent| agent.issues.iter())
+        .filter(|issue| matches!(issue, AgentIssue::SlotCannotStart(params) if !params.error.is_empty()))
+        .count();
+
+    assert!(
+        slot_cannot_start_count > 0,
+        "expected at least one SlotCannotStart issue with non-empty error"
+    );
+
+    cluster.shutdown().await?;
+
+    Ok(())
+}

--- a/paddler_tests/tests/agent_reports_slot_cannot_start_for_metal_quantized_distinct_kv_in_process.rs
+++ b/paddler_tests/tests/agent_reports_slot_cannot_start_for_metal_quantized_distinct_kv_in_process.rs
@@ -1,0 +1,88 @@
+#![cfg(all(
+    feature = "tests_that_use_compiled_paddler",
+    feature = "tests_that_use_llms",
+    feature = "metal"
+))]
+
+use std::time::Duration;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use paddler_tests::current_test_device::current_test_device;
+use paddler_tests::in_process_cluster_params::InProcessClusterParams;
+use paddler_tests::model_card::ModelCard;
+use paddler_tests::model_card::qwen3_0_6b::qwen3_0_6b;
+use paddler_tests::start_in_process_cluster::start_in_process_cluster;
+use paddler_tests::test_device::TestDevice;
+use paddler_types::agent_desired_model::AgentDesiredModel;
+use paddler_types::agent_issue::AgentIssue;
+use paddler_types::balancer_desired_state::BalancerDesiredState;
+use paddler_types::kv_cache_dtype::KvCacheDtype;
+
+#[serial_test::file_serial(model_load, path => "../target/model_load.lock")]
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_reports_slot_cannot_start_for_metal_quantized_distinct_kv_in_process() -> Result<()>
+{
+    let device = current_test_device()?;
+
+    if !matches!(device, TestDevice::Metal) {
+        return Ok(());
+    }
+
+    device.require_available()?;
+
+    let ModelCard {
+        gpu_layer_count,
+        reference,
+    } = qwen3_0_6b();
+
+    let mut inference_parameters = device.inference_parameters_for_full_offload(gpu_layer_count);
+
+    inference_parameters.k_cache_dtype = KvCacheDtype::Q8_0;
+    inference_parameters.v_cache_dtype = KvCacheDtype::Q4_0;
+
+    let mut cluster = start_in_process_cluster(InProcessClusterParams {
+        spawn_agent: true,
+        slots_per_agent: 1,
+        desired_state: BalancerDesiredState {
+            chat_template_override: None,
+            inference_parameters,
+            model: AgentDesiredModel::HuggingFace(reference),
+            multimodal_projection: AgentDesiredModel::None,
+            use_chat_template_override: false,
+        },
+        wait_for_slots_ready: false,
+        ..InProcessClusterParams::default()
+    })
+    .await?;
+
+    let snapshot = tokio::time::timeout(
+        Duration::from_secs(10),
+        cluster.agents.until(|snapshot| {
+            snapshot.agents.iter().any(|agent| {
+                agent
+                    .issues
+                    .iter()
+                    .any(|issue| matches!(issue, AgentIssue::SlotCannotStart(_)))
+            })
+        }),
+    )
+    .await
+    .context("agent did not report SlotCannotStart within 10s")??;
+
+    let slot_cannot_start_count = snapshot
+        .agents
+        .iter()
+        .flat_map(|agent| agent.issues.iter())
+        .filter(|issue| matches!(issue, AgentIssue::SlotCannotStart(params) if !params.error.is_empty()))
+        .count();
+
+    assert!(
+        slot_cannot_start_count > 0,
+        "expected at least one SlotCannotStart issue with non-empty error"
+    );
+
+    cluster.shutdown().await?;
+
+    Ok(())
+}

--- a/paddler_tests/tests/agent_reports_slot_cannot_start_for_metal_quantized_distinct_kv_subprocess.rs
+++ b/paddler_tests/tests/agent_reports_slot_cannot_start_for_metal_quantized_distinct_kv_subprocess.rs
@@ -1,0 +1,88 @@
+#![cfg(all(
+    feature = "tests_that_use_compiled_paddler",
+    feature = "tests_that_use_llms",
+    feature = "metal"
+))]
+
+use std::time::Duration;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use paddler_tests::current_test_device::current_test_device;
+use paddler_tests::model_card::ModelCard;
+use paddler_tests::model_card::qwen3_0_6b::qwen3_0_6b;
+use paddler_tests::start_subprocess_cluster::start_subprocess_cluster;
+use paddler_tests::subprocess_cluster_params::SubprocessClusterParams;
+use paddler_tests::test_device::TestDevice;
+use paddler_types::agent_desired_model::AgentDesiredModel;
+use paddler_types::agent_issue::AgentIssue;
+use paddler_types::balancer_desired_state::BalancerDesiredState;
+use paddler_types::kv_cache_dtype::KvCacheDtype;
+
+#[serial_test::file_serial(model_load, path => "../target/model_load.lock")]
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_reports_slot_cannot_start_for_metal_quantized_distinct_kv_subprocess() -> Result<()>
+{
+    let device = current_test_device()?;
+
+    if !matches!(device, TestDevice::Metal) {
+        return Ok(());
+    }
+
+    device.require_available()?;
+
+    let ModelCard {
+        gpu_layer_count,
+        reference,
+    } = qwen3_0_6b();
+
+    let mut inference_parameters = device.inference_parameters_for_full_offload(gpu_layer_count);
+
+    inference_parameters.k_cache_dtype = KvCacheDtype::Q8_0;
+    inference_parameters.v_cache_dtype = KvCacheDtype::Q4_0;
+
+    let mut cluster = start_subprocess_cluster(SubprocessClusterParams {
+        agent_count: 1,
+        slots_per_agent: 1,
+        wait_for_slots_ready: false,
+        desired_state: Some(BalancerDesiredState {
+            chat_template_override: None,
+            inference_parameters,
+            model: AgentDesiredModel::HuggingFace(reference),
+            multimodal_projection: AgentDesiredModel::None,
+            use_chat_template_override: false,
+        }),
+        ..SubprocessClusterParams::default()
+    })
+    .await?;
+
+    let snapshot = tokio::time::timeout(
+        Duration::from_secs(10),
+        cluster.agents.until(|snapshot| {
+            snapshot.agents.iter().any(|agent| {
+                agent
+                    .issues
+                    .iter()
+                    .any(|issue| matches!(issue, AgentIssue::SlotCannotStart(_)))
+            })
+        }),
+    )
+    .await
+    .context("agent did not report SlotCannotStart within 10s")??;
+
+    let slot_cannot_start_count = snapshot
+        .agents
+        .iter()
+        .flat_map(|agent| agent.issues.iter())
+        .filter(|issue| matches!(issue, AgentIssue::SlotCannotStart(params) if !params.error.is_empty()))
+        .count();
+
+    assert!(
+        slot_cannot_start_count > 0,
+        "expected at least one SlotCannotStart issue with non-empty error"
+    );
+
+    cluster.shutdown().await?;
+
+    Ok(())
+}

--- a/paddler_tests/tests/continuous_batch_generates_tokens_with_distinct_k_and_v_cache_dtypes.rs
+++ b/paddler_tests/tests/continuous_batch_generates_tokens_with_distinct_k_and_v_cache_dtypes.rs
@@ -30,7 +30,7 @@ async fn continuous_batch_generates_tokens_with_distinct_k_and_v_cache_dtypes() 
     let mut inference_parameters = device.inference_parameters_for_full_offload(gpu_layer_count);
 
     inference_parameters.k_cache_dtype = KvCacheDtype::Q8_0;
-    inference_parameters.v_cache_dtype = KvCacheDtype::Q4_0;
+    inference_parameters.v_cache_dtype = KvCacheDtype::F16;
 
     let cluster = start_in_process_cluster(InProcessClusterParams {
         spawn_agent: true,

--- a/paddler_tests/tests/harness_agents_watcher.rs
+++ b/paddler_tests/tests/harness_agents_watcher.rs
@@ -7,6 +7,8 @@ use paddler_tests::agents_status::assert_slots_total_at_least::assert_slots_tota
 use paddler_tests::agents_stream_watcher::AgentsStreamWatcher;
 use paddler_types::agent_controller_pool_snapshot::AgentControllerPoolSnapshot;
 use paddler_types::agent_controller_snapshot::AgentControllerSnapshot;
+use paddler_types::agent_issue::AgentIssue;
+use paddler_types::agent_issue_params::ModelPath;
 use paddler_types::agent_state_application_status::AgentStateApplicationStatus;
 
 fn make_snapshot(agent_id: &str, slots_total: i32) -> AgentControllerPoolSnapshot {
@@ -84,5 +86,35 @@ async fn until_errors_when_stream_closes_before_match() {
     assert!(
         outcome.is_err(),
         "expected error when stream closes without satisfying predicate"
+    );
+}
+
+#[tokio::test]
+async fn wait_for_slots_ready_includes_agent_id_in_error() {
+    let mut snapshot = make_snapshot("agent-x", 0);
+    let mut issues = BTreeSet::new();
+    issues.insert(AgentIssue::ModelFileDoesNotExist(ModelPath {
+        model_path: "/nonexistent".to_owned(),
+    }));
+    snapshot.agents[0].issues = issues;
+
+    let fixture = stream::iter(vec![Ok(snapshot)]);
+    let mut watcher = AgentsStreamWatcher::from_stream(Box::pin(fixture));
+
+    let outcome = watcher.wait_for_slots_ready(1, 1).await;
+
+    assert!(
+        outcome.is_err(),
+        "expected error when an agent reports issues"
+    );
+
+    let error_chain = format!(
+        "{:#}",
+        outcome.err().unwrap_or_else(|| anyhow!("unreachable"))
+    );
+
+    assert!(
+        error_chain.contains("agent-x"),
+        "expected agent id in error chain, got: {error_chain}"
     );
 }


### PR DESCRIPTION
Three things in this PR:
1. New test.integration.metal target.
2. Once the metal target was added, I needed to update the Metal backend name in device detection because llama.cpp uses "MTL" not "Metal" and without this change, the tests were failing (here's the reason for this: https://github.com/ggml-org/llama.cpp/blob/master/ggml/src/ggml-metal/ggml-metal.cpp#L13)
3. Next, I run into this issue: "`llama_init_from_model: failed to initialize the context: quantized V cache was requested, but this requires Flash Attention`" and the tests on metal just got stuck. I updated the `continuous_batch_generates_tokens_with_distinct_k_and_v_cache_dtypes.rs` test so that V cache uses `F16` instead of `Q4_0`. I think this is still aligned with the test's intention and I needed this because of how ggml metal works with Flash Attention (https://github.com/ggml-org/llama.cpp/blob/master/ggml/src/ggml-metal/ggml-metal-device.m#L1147)